### PR TITLE
Fixed issue when promises return arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (promises) {
   const iterateeFunc = (previousPromise, currentPromise) => {
     return previousPromise
       .then(function (result) {
-        if (count++ !== 0) results = results.concat(result);
+        if (count++ !== 0) results.push(result);
         return currentPromise(result, results, count);
       })
   }


### PR DESCRIPTION
Changed concat to push because concat partially flattens arrays but you never actually want to do that here.